### PR TITLE
add option to generate screw inserts

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -165,6 +165,11 @@
                             <option value="false">No</option>
                             <option value="true">Yes</option>
                         </select>
+                        <label for="screw-inserts">Screw inserts</label>
+                        <select id="screw-inserts" name="screw-inserts">
+                            <option value="false">No screw inserts</option>
+                            <option value="true">Screw inserts</option>
+                        </select>
                     </fieldset>
                     <label for="keycaps">
                         <h3>Keycaps</h3>

--- a/src/dactyl_keyboard/dactyl.clj
+++ b/src/dactyl_keyboard/dactyl.clj
@@ -1261,6 +1261,7 @@
   (let [use-inner-column? (get c :configuration-use-inner-column?)
         show-caps? (get c :configuration-show-caps?)
         use-promicro-usb-hole? (get c :configuration-use-promicro-usb-hole?)
+        use-screw-inserts? (get c :configuration-use-screw-inserts?)
         use-trrs? (get c :configuration-use-trrs?)
         use-wire-post? (get c :configuration-use-wire-post?)]
     (difference
@@ -1278,6 +1279,10 @@
       (pinky-connectors c)
       (difference
        (union (case-walls c)
+              (if use-screw-inserts?
+                (screw-insert-outers c)
+                ()
+              )
               (if use-promicro-usb-hole?
                 (union (pro-micro-holder c)
                        (trrs-usb-holder-holder c))
@@ -1286,6 +1291,10 @@
               (if use-trrs?
                 (trrs-holder c)
                 ()))
+       (if use-screw-inserts?
+        (screw-insert-holes c)
+        ()
+       )
        (if use-trrs?
          (trrs-holder-hole c)
          (rj9-space c))
@@ -1315,7 +1324,8 @@
                  :configuration-show-caps? false
                  :configuration-use-last-row? false
                  :configuration-use-wide-pinky? false
-                 :configuration-use-wire-post? false))
+                 :configuration-use-wire-post? false
+                 :configuration-use-screw-inserts? false))
 
 (spit "things/right.scad"
       (write-scad (model-right c)))

--- a/src/dactyl_keyboard/handler.clj
+++ b/src/dactyl_keyboard/handler.clj
@@ -43,6 +43,7 @@
         param-keyboard-z-offset (parse-int (get params "keyboard-z-offset"))
         param-wide-pinky (parse-bool (get params "wide-pinky"))
         param-wire-post (parse-bool (get params "wire-post"))
+        param-screw-inserts (parse-bool (get params "screw-inserts"))
         param-show-keycaps (parse-bool (get params "show-keycaps"))
         c (hash-map :configuration-nrows param-nrows
                     :configuration-ncols param-ncols
@@ -64,7 +65,8 @@
                     :configuration-show-caps? param-show-keycaps
                     :configuration-use-last-row? param-last-row
                     :configuration-use-wide-pinky? param-wide-pinky
-                    :configuration-use-wire-post? param-wire-post)
+                    :configuration-use-wire-post? param-wire-post
+                    :configuration-use-screw-inserts? param-screw-inserts)
         generated-scad (generate-scad c)]
     {:status 200
      :headers {"Content-Type" "application/octet-stream"


### PR DESCRIPTION
Hi!

First of all, thanks for your great tool to generate dactyl manuforms. I missed the option to create screw inserts. This pull request will add this functionality.

I'd love it if you could merge this.

Kind regards,