### PR TITLE
initial add of choc switch types

### DIFF
--- a/src/dactyl_keyboard/common.clj
+++ b/src/dactyl_keyboard/common.clj
@@ -214,6 +214,7 @@
         use-alps?           (case switch-type
                               :alps true
                               false) #_(get c :configuration-use-alps?)
+        use-choc?           (case switch-type :choc true false)
         use-hotswap?        (get c :configuration-use-hotswap?)
         plate-projection?   (get c :configuration-plate-projection? false)
         alps-fill-in        (translate [0 0 (/ plate-thickness 2)] (cube alps-width alps-height plate-thickness))
@@ -255,8 +256,9 @@
                                    left-wall
                                    (if create-side-nub? (with-fn 100 side-nub) ()))
         ; the bottom of the hole.
+        swap-holder-z-offset (if use-choc? 2 -1.5)
         swap-holder         (->> (cube (+ keyswitch-width 3) (/ (+ keyswitch-height 3) 2) 3)
-                                 (translate [0 (/ (+ keyswitch-height 3) 4) -1.5]))
+                                 (translate [0 (/ (+ keyswitch-height 3) 4) swap-holder-z-offset]))
         ; for the main axis
         main-axis-hole      (->> (cylinder (/ 4.0 2) 10)
                                  (with-fn 12))
@@ -276,8 +278,9 @@
                                  (with-fn 8))
         friction-hole-right (translate [5 0 0] friction-hole)
         friction-hole-left  (translate [-5 0 0] friction-hole)
+        hotswap-base-z-offset (if use-choc? 0 -2.6)
         hotswap-base-shape  (->> (cube 19 6.2 3.5)
-                                 (translate [0 4 -2.6]))
+                                 (translate [0 4 hotswap-base-z-offset]))
         hotswap-holder      (difference swap-holder
                                         main-axis-hole
                                         plus-hole

--- a/src/dactyl_keyboard/handler.clj
+++ b/src/dactyl_keyboard/handler.clj
@@ -63,6 +63,7 @@
         switch-type                 (case (get p "keys.switch-type")
                                       "mx" :mx
                                       "alps" :alps
+                                      "choc" :choc
                                       :box)
         param-inner-column          (parse-bool (get p "keys.inner-column"))
         param-hide-last-pinky       (parse-bool (get p "keys.hide-last-pinky"))


### PR DESCRIPTION
This is a first pass at adding a choc switch type.

I haven't added the option to choose the choc switch type to the manuform.html yet.
I'm wondering what you think of using prettier as a formatter. I formatted manuform.html in my other PR. Depending on your reaction, I will change manuform.html after.

I think this is a first pass and might require amendments later.

Let me know if you think anything is amiss.

fix https://github.com/ibnuda/dactyl-keyboard/issues/50