### PR TITLE
Add experimental support for Kailh switches

### DIFF
--- a/resources/manuform.html
+++ b/resources/manuform.html
@@ -81,6 +81,7 @@
           <option value="mx">MX</option>
           <option value="alps">Alps</option>
           <option value="choc">Choc (Experimental)</option>
+          <option value="kailh">Kailh (Experimental)</option>
         </select>
         <label for="keys.inner-column">Inner Index Finger's Column?</label>
         <select id="keys.inner-column" name="keys.inner-column">

--- a/src/dactyl_keyboard/common.clj
+++ b/src/dactyl_keyboard/common.clj
@@ -232,7 +232,9 @@
         use-alps?           (case switch-type
                               :alps true
                               false) #_(get c :configuration-use-alps?)
-        use-choc?           (case switch-type :choc true false)
+        use-choc?           (case switch-type
+                              :choc true
+                              false)
         use-hotswap?        (get c :configuration-use-hotswap?)
         plate-projection?   (get c :configuration-plate-projection? false)
         fill-in             (translate [0 0 (/ plate-thickness 2)] (cube alps-width alps-height plate-thickness))
@@ -252,18 +254,18 @@
                                                (/ plate-thickness 2)])))
         left-wall           (case switch-type
                               :alps (union (->> (cube 2 (+ keyswitch-height 3) plate-thickness)
-                                          (translate [(+ (/ 2 2) (/ 15.6 2))
-                                                      0
-                                                      (/ plate-thickness 2)]))
-                                     (->> (cube 1.5 (+ keyswitch-height 3) 1.0)
-                                          (translate [(+ (/ 1.5 2) (/ alps-notch-width 2))
-                                                      0
-                                                      (- plate-thickness
-                                                         (/ alps-notch-height 2))])))
+                                                (translate [(+ (/ 2 2) (/ 15.6 2))
+                                                            0
+                                                            (/ plate-thickness 2)]))
+                                           (->> (cube 1.5 (+ keyswitch-height 3) 1.0)
+                                                (translate [(+ (/ 1.5 2) (/ alps-notch-width 2))
+                                                            0
+                                                            (- plate-thickness
+                                                               (/ alps-notch-height 2))])))
                               :choc (->> (cube holder-thickness (+ keyswitch-height 3.3) (* plate-thickness 0.65))
-                                   (translate [(+ (/ holder-thickness 2) (/ keyswitch-width 2))
-                                               0
-                                               (* plate-thickness 0.7)]))
+                                         (translate [(+ (/ holder-thickness 2) (/ keyswitch-width 2))
+                                                     0
+                                                     (* plate-thickness 0.7)]))
                               (->> (cube holder-thickness (+ keyswitch-height 3.3) plate-thickness)
                                    (translate [(+ (/ holder-thickness 2) (/ keyswitch-width 2))
                                                0
@@ -276,9 +278,15 @@
                                                         0
                                                         (/ plate-thickness 2)]))))
         ; the hole's wall.
-        plate-half          (union top-wall
-                                   left-wall
-                                   (if create-side-nub? (with-fn 100 side-nub) ()))
+        kailh-cutout (->> (cube (/ keyswitch-width 3) 1.6 (+ plate-thickness 1.8))
+                          (translate [0
+                                      (+ (/ 1.5 2) (+ (/ keyswitch-height 2)))
+                                      (/ plate-thickness)]))
+        plate-half          (case switch-type
+                              :kailh (union (difference top-wall kailh-cutout) left-wall)
+                              (union top-wall
+                                     left-wall
+                                     (if create-side-nub? (with-fn 100 side-nub))))
         ; the bottom of the hole.
         swap-holder-z-offset (if use-choc? 1.5 -1.5)
         swap-holder         (->> (cube (+ keyswitch-width 3) (/ (+ keyswitch-height 3) 2) 3)
@@ -496,4 +504,3 @@
                           (key-position c column row (map + (wall-locate2  1  0) [(/ mount-width 2) 0 0])))))]
     (->> (screw-insert-shape bottom-radius top-radius height)
          (translate [(first position) (second position) (/ height 2)]))))
-

--- a/src/dactyl_keyboard/handler.clj
+++ b/src/dactyl_keyboard/handler.clj
@@ -68,6 +68,7 @@
                                       "mx" :mx
                                       "alps" :alps
                                       "choc" :choc
+                                      "kailh" :kailh
                                       :box)
         param-inner-column          (case (get p "keys.inner-column")
                                       "innie" :innie
@@ -194,6 +195,7 @@
                                     "mx" :mx
                                     "alps" :alps
                                     "choc" :choc
+                                    "kailh" :kailh
                                     :box)
         param-hide-last-pinky     (parse-bool (get p "keys.hide-last-pinky"))
         param-alpha               (parse-int (get p "curve.alpha"))


### PR DESCRIPTION
This adds the option to use Kailh switches with the cutouts in place so the notches on the box hook correctly.

Please review. This is the first time I write *any* Clojure at all, and without much understanding of OpenSCAD either.

This fixes the issue seen on https://github.com/ibnuda/dactyl-keyboard/issues/59#issuecomment-729281568.

![IMG_3024](https://user-images.githubusercontent.com/399431/99601879-3bfd0d00-29f8-11eb-8fd8-4c43f610ac0e.jpeg)
