### PR TITLE
Improve hotswap holes

### DIFF
--- a/src/dactyl_keyboard/common.clj
+++ b/src/dactyl_keyboard/common.clj
@@ -315,10 +315,12 @@
                                  (translate [0 3 hotswap-base-z-offset]))
         hotswap-holder      (difference swap-holder
                                         main-axis-hole
-                                        plus-hole
-                                        minus-hole
-                                        plus-hole-mirrored
-                                        minus-hole-mirrored
+                                        (if :is-right?
+                                          plus-hole
+                                          plus-hole-mirrored)
+                                        (if :is-right?
+                                          minus-hole
+                                          minus-hole-mirrored)
                                         friction-hole-left
                                         friction-hole-right
                                         hotswap-base-shape)]

--- a/src/dactyl_keyboard/common.clj
+++ b/src/dactyl_keyboard/common.clj
@@ -236,6 +236,7 @@
                               :choc true
                               false)
         use-hotswap?        (get c :configuration-use-hotswap?)
+        is-right?        (get c :is-right?)
         plate-projection?   (get c :configuration-plate-projection? false)
         fill-in             (translate [0 0 (/ plate-thickness 2)] (cube alps-width alps-height plate-thickness))
         holder-thickness    1.65
@@ -315,10 +316,10 @@
                                  (translate [0 3 hotswap-base-z-offset]))
         hotswap-holder      (difference swap-holder
                                         main-axis-hole
-                                        (if :is-right?
+                                        (if is-right?
                                           plus-hole
                                           plus-hole-mirrored)
-                                        (if :is-right?
+                                        (if is-right?
                                           minus-hole
                                           minus-hole-mirrored)
                                         friction-hole-left

--- a/src/dactyl_keyboard/handler.clj
+++ b/src/dactyl_keyboard/handler.clj
@@ -263,7 +263,9 @@
 
                                    :configuration-show-caps?           param-show-keycaps
 
-                                   :configuration-use-screw-inserts?   param-screw-inserts}
+                                   :configuration-use-screw-inserts?   param-screw-inserts
+
+                                   :is-right?                            is-right?}
         generated-file            (cond
                                     generate-plate? {:file      (g/generate-plate-dl c is-right?)
                                                      :extension "scad"}

--- a/src/dactyl_keyboard/handler.clj
+++ b/src/dactyl_keyboard/handler.clj
@@ -168,7 +168,9 @@
                                      :configuration-show-caps?             param-show-keycaps
                                      :configuration-use-wide-pinky?        param-wide-pinky
                                      :configuration-use-wire-post?         param-wire-post
-                                     :configuration-use-screw-inserts?     param-screw-inserts}
+                                     :configuration-use-screw-inserts?     param-screw-inserts
+
+                                     :is-right?                            is-right?}
         generated-file              (cond
                                       generate-plate? {:file      (g/generate-plate-dm c is-right?)
                                                        :part      "plate"

--- a/src/dactyl_keyboard/lightcycle.clj
+++ b/src/dactyl_keyboard/lightcycle.clj
@@ -108,7 +108,7 @@
         use-alps?            (get c :configuration-use-alps?)
         use-lastrow?         (get c :configuration-use-lastrow?)
         hide-last-pinky?     (get c :configuration-hide-last-pinky?)
-        rotation-for-keyhole (if use-alps? 0 270)
+        rotation-for-keyhole (if use-alps? 0 0)
         columns              (range 0 ncols)
         rows                 (frows c)
         last-pinky-location  (fn [column row]

--- a/src/dactyl_keyboard/manuform.clj
+++ b/src/dactyl_keyboard/manuform.clj
@@ -446,8 +446,8 @@
 
 (defn thumb [c]
   (union
-   (thumb-1x-layout c  (single-plate c))
-   (thumb-15x-layout c (rotate (/ pi 2) [0 0 1] (single-plate c)))
+   (thumb-1x-layout c (single-plate c))
+   (thumb-15x-layout c (single-plate c))
    (thumb-15x-layout c larger-plate)))
 
 (def thumb-post-tr


### PR DESCRIPTION
Tested on left and right sides of manuform and lightcycle.

Hotswap now has two holes instead of four:
![image](https://user-images.githubusercontent.com/21185399/111929424-a7c9b200-8a8c-11eb-9fae-f4a460c7264b.png)

I also rotated the keys on the lightcycle and the top of the thumb on the manuform, since they appeared to be facing the wrong way (lmk if this was supposed to be this way, I can remove it from the pull request).
It used to be like this:
![image](https://user-images.githubusercontent.com/21185399/111929623-48b86d00-8a8d-11eb-91dd-28fda6823b98.png)
