### PR TITLE
Added snap-in key holder

### DIFF
--- a/resources/json-help.html
+++ b/resources/json-help.html
@@ -96,8 +96,8 @@
                     </li>
                     <li><code>last-row</code>: the number of keys on the last row. Default is <code>"two"</code>.
                         Accepted values: <code>"zero"</code>,<code>"two"</code>,<code>"full"</code>.</li>
-                    <li><code>switch-type</code>: whether it uses BOX, MX, or Alps style switch. Default is
-                        <code>BOX</code>. Accepted values: <code>box</code>, <code>mx</code>, <code>alps</code></li>
+                    <li><code>switch-type</code>: whether it uses BOX, MX, mx snap in, or Alps style switch. Default is
+                        <code>BOX</code>. Accepted values: <code>box</code>, <code>mx</code>, <code>mx-snap-in</code> <code>alps</code></li>
                     <li><code>inner-columns</code>: whether it uses the inner-column or not. Default is
                         <code>normie</code>. Accepted values: <code>normie</code>, <code>innie</code>, and
                         <code>outie</code>.</li>

--- a/resources/lightcycle.html
+++ b/resources/lightcycle.html
@@ -52,6 +52,7 @@
                 <select id="keys.switch-type" name="keys.switch-type">
                     <option value="box">Box and MX</option>
                     <option value="mx">MX</option>
+                    <option value="mx-snap-in">MX snap-in (one way)</option>
                     <option value="alps">Alps</option>
                     <option value="choc">Choc (Experimental)</option>
                 </select>

--- a/resources/manuform.html
+++ b/resources/manuform.html
@@ -79,6 +79,7 @@
         <select id="keys.switch-type" name="keys.switch-type">
           <option value="box">Box and MX</option>
           <option value="mx">MX</option>
+          <option value="mx-snap-in">MX snap-in (one way)</option>
           <option value="alps">Alps</option>
           <option value="choc">Choc (Experimental)</option>
           <option value="kailh">Kailh (Experimental)</option>

--- a/src/dactyl_keyboard/common.clj
+++ b/src/dactyl_keyboard/common.clj
@@ -228,7 +228,11 @@
   (let [switch-type         (get c :configuration-switch-type)
         create-side-nub?    (case switch-type
                               :mx true
+                              :mx-snap-in true
                               false) #_(get c :configuration-create-side-nub?)
+      nub-height           (case switch-type
+                              :mx-snap-in 0.75
+                              0) 
         use-alps?           (case switch-type
                               :alps true
                               false) #_(get c :configuration-use-alps?)
@@ -272,11 +276,11 @@
                                                (/ plate-thickness 2)])))
         side-nub            (->> (binding [*fn* 30] (cylinder 1 2.75))
                                  (rotate (/ pi 2) [1 0 0])
-                                 (translate [(+ (/ keyswitch-width 2)) 0 1])
-                                 (hull (->> (cube 1.5 2.75 plate-thickness)
+                                 (translate [(+ (/ keyswitch-width 2)) 0 (+ 1 nub-height)])
+                                 (hull (->> (cube 1.5 2.75 (- plate-thickness nub-height))
                                             (translate [(+ (/ 1.5 2) (/ keyswitch-width 2))
                                                         0
-                                                        (/ plate-thickness 2)]))))
+                                                        (/ (+ plate-thickness nub-height) 2)]))))
         ; the hole's wall.
         kailh-cutout (->> (cube (/ keyswitch-width 3) 1.6 (+ plate-thickness 1.8))
                           (translate [0

--- a/src/dactyl_keyboard/handler.clj
+++ b/src/dactyl_keyboard/handler.clj
@@ -66,6 +66,7 @@
                                       :two)
         param-switch-type           (case (get p "keys.switch-type")
                                       "mx" :mx
+                                      "mx-snap-in" :mx-snap-in
                                       "alps" :alps
                                       "choc" :choc
                                       "kailh" :kailh
@@ -201,6 +202,7 @@
                                     :five)
         param-switch-type         (case (get p "keys.switch-type")
                                     "mx" :mx
+                                    "mx-snap-in" :mx-snap-in
                                     "alps" :alps
                                     "choc" :choc
                                     "kailh" :kailh


### PR DESCRIPTION
Added a variation of the MX key hole type, where the switch firmly snaps into the hole. This way, the switches do not need to be hot glued into place. Very difficult to remove.

The extra space below the nub allows the bottom ledge of the switch to snap into place.

![image](https://user-images.githubusercontent.com/21185399/112200011-2c2f4880-8be5-11eb-9ea8-fc7c8c96a50a.png)

![image](https://user-images.githubusercontent.com/21185399/112199973-1f125980-8be5-11eb-92e2-7b6cdbb3177d.png)
