### PR TITLE
Fix parsing of connector.type in manuform api body

### DIFF
--- a/src/dactyl_keyboard/handler.clj
+++ b/src/dactyl_keyboard/handler.clj
@@ -343,7 +343,7 @@
                         :configuration-rotate-x-angle              (/ pi (get curve :rotate-x 15))
 
                         :configuration-use-external-holder?        (get connector :external false)
-                        :configuration-connector-type              (get connector :type :none)
+                        :configuration-connector-type              (keyword (get connector :type "none"))
                         :configuration-use-promicro-usb-hole?      (get connector :micro-usb false)
 
                         :configuration-thumb-cluster-offset-x      (get form :thumb-cluster-offset-x 6)


### PR DESCRIPTION
Connector type is type of string, which should be parsed in form of `(keyword (get connector :type "none"))` rather than `(get connector :type :none)`.