### PR TITLE
Fix param parsing to thumb three-mini in manuform web form api

### DIFF
--- a/src/dactyl_keyboard/handler.clj
+++ b/src/dactyl_keyboard/handler.clj
@@ -55,6 +55,7 @@
         param-thumb-count                 (case (get p "keys.thumb-count")
                                             "two" :two
                                             "three" :three
+                                            "three-mini" :three-mini
                                             "four" :four
                                             "five" :five
                                             :six)


### PR DESCRIPTION
The conversion from string `three-mini` to keyword `:three-mini` is missing from function `generate-manuform` in `handler.clj`.

Tested in local.