### PR TITLE
Check use-external-holder before union internal holders

### DIFF
--- a/src/dactyl_keyboard/manuform.clj
+++ b/src/dactyl_keyboard/manuform.clj
@@ -1587,12 +1587,14 @@
                                  (rj9-space frj9-start c))
                 (case-walls c))
               (if use-screw-inserts? (screw-insert-outers screw-placement c) ())
-              (case connector-type
-                :trrs (union (pro-micro-holder c)
-                             (trrs-usb-holder-holder c)
-                             (trrs-holder c))
-                :rj9 (union (usb-holder fusb-holder-position c)
-                            (rj9-holder frj9-start c))
+              (if-not use-external-holder?
+                (case connector-type
+                  :trrs (union (pro-micro-holder c)
+                               (trrs-usb-holder-holder c)
+                               (trrs-holder c))
+                  :rj9 (union (usb-holder fusb-holder-position c)
+                              (rj9-holder frj9-start c))
+                  ())
                 ()))
        (if use-screw-inserts? (screw-insert-holes screw-placement c) ())
        (if-not use-external-holder?


### PR DESCRIPTION
Test params. Connector is external and trrs.
```json
{
    "keys": {
        "columns": 7,
        "rows": 5,
        "thumb-count": "six",
        "last-row": "full",
        "switch-type": "mx-snap-in",
        "inner-column": "normie",
        "hide-last-pinky": false
    },
    "curve": {
        "alpha": 12,
        "pinky-alpha": 12,
        "beta": 36,
        "centercol": 4,
        "tenting": 15,
        "rotate-x": 180
    },
    "connector": {
        "external": true,
        "type": "trrs",
        "micro-usb": true
    },
    "form": {
        "stagger-pinky-y": -13.0,
        "thumb-cluster-offset-x": 6.0,
        "hotswap": false,
        "stagger-index-y": 0.0,
        "thumb-middle-left-tenting-y": 69.0,
        "thumb-top-left-offset-y": -16.0,
        "wire-post": false,
        "stagger": true,
        "stagger-ring-z": 0.0,
        "thumb-top-right-tenting-y": 69.0,
        "wall-thickness": 3.0,
        "stagger-middle-z": -6.5,
        "screw-inserts": true,
        "web-thickness": 7.0,
        "thumb-top-left-tenting-z": 69.0,
        "thumb-top-left-tenting-x": 69.0,
        "thumb-middle-left-offset-x": -53.0,
        "stagger-middle-y": 2.8,
        "thumb-middle-left-offset-z": -12.0,
        "thumb-middle-left-offset-y": -26.0,
        "height-offset": 10,
        "thumb-middle-left-tenting-x": 69.0,
        "wide-pinky": false,
        "thumb-top-right-offset-x": -15.0,
        "stagger-index-z": 0.0,
        "thumb-top-right-tenting-z": 69.0,
        "thumb-cluster-offset-z": 7.0,
        "custom-thumb-cluster": false,
        "thumb-top-right-tenting-x": 69.0,
        "stagger-ring-y": 0.0,
        "thumb-middle-left-tenting-z": 69.0,
        "thumb-top-left-tenting-y": 69.0,
        "thumb-top-right-offset-y": -10.0,
        "thumb-top-right-offset-z": -5.0,
        "thumb-top-left-offset-x": -35.0,
        "thumb-cluster-offset-y": -3.0,
        "thumb-top-left-offset-z": -2.0,
        "stagger-pinky-z": 6.0
    },
    "misc": {
        "keycaps": false,
        "right-side": true
    }
}
```

![remove-internal-holder-from-external-holder](https://user-images.githubusercontent.com/28599139/129297697-47be1074-2a92-466f-bf77-193627169110.png)

The left image is generated with current refaktor branch. The pro-micro-holder (I called L hook before) is useless. The additional cube is part of internal trrs holder, which should be cut before plug the external holder.
The right image is generated with my code change. Check `use-external-holder` before union internal holder, just like check `use-external-holder` before difference internal holder hole and space.

Code snippet which checks `use-external-holder` before difference internal holder hole and space.
https://github.com/ibnuda/dactyl-keyboard/blob/84e86a58582954f60f7844ef571f62e69b9fd02d/src/dactyl_keyboard/manuform.clj#L1598-L1605