### PR TITLE
fix rotation around row axis

### DIFF
--- a/resources/manuform.html
+++ b/resources/manuform.html
@@ -161,7 +161,7 @@
         <select id="curve.rotate-x" name="curve.rotate-x">
           <option value="180">pi/180</option>
           {% for ta in rotate-x %}
-          <option value="-{{ta}}">-pi/{{ta}}</option>
+          <option value="{{ta}}">pi/{{ta}}</option>
           {% endfor %}
         </select>
       </fieldset>

--- a/src/dactyl_keyboard/handler.clj
+++ b/src/dactyl_keyboard/handler.clj
@@ -38,7 +38,7 @@
                                 ;; :thumb-locations        ["tl" "tr" "ml" "mr" "bl" "br"]
                                 :thumb-tenting          (range -90 100 5)
                                 :rotate-x               (range 36 -36 -1)
-                                :height-offset          (range 4 26 2)}))
+                                :height-offset          (range 4 52 2)}))
 
 (defn lightcycle [_]
   (render-file "lightcycle.html" {:column-curvature       (range 12 22)


### PR DESCRIPTION
When selecting a negative value for rotation around the row axis, it will generate a bug.
This is a fix for that.
Also when selecting a positive angle for row axis rotation, you need to have more height offset. This PR adds that too.