### PR TITLE
Simplify code for screw placement

### DIFF
--- a/src/dactyl_keyboard/common.clj
+++ b/src/dactyl_keyboard/common.clj
@@ -522,8 +522,9 @@
                       (+ screw-insert-bottom-radius 1.6)
                       (+ screw-insert-top-radius 1.6)
                       (+ screw-insert-height 1.5)))
-(defn screw-insert-screw-holes
-  "TODO: doc."
+(defn screw-insert-holes-plate
+  "TODO: doc.
+   Takes a function that places screw holes for the bottom plate of the case."
   [placement-function c]
   (placement-function c 1.7 1.7 350))
 

--- a/src/dactyl_keyboard/common.clj
+++ b/src/dactyl_keyboard/common.clj
@@ -521,15 +521,10 @@
   (screw-insert-shape (+ screw-insert-bottom-radius screw-insert-wall-thickness)
                       (+ screw-insert-top-radius screw-insert-wall-thickness)
                       (+ screw-insert-height (- screw-insert-wall-thickness 0.1))))
-(defn screw-insert-hole-plate
-  "For the bottom plate of the case: creates the shape of a through-hole that
-   fits an M3 screw"
+(defn screw-hole
+  "For the bottom plate of the case: creates a 2D shape of an M3 screw hole."
   [c]
-  (let [m3-through-hole-radius 1.7
-        max-height 350]
-    (screw-insert-shape m3-through-hole-radius
-                        m3-through-hole-radius
-                        max-height)))
+  (with-fn 20 (circle 1.7)))
 
 (defn screw-placement-common
   "Model-independent utility for positioning screw inserts based on their

--- a/src/dactyl_keyboard/common.clj
+++ b/src/dactyl_keyboard/common.clj
@@ -499,36 +499,42 @@
                    (/ (+ (last usb-holder-size) usb-holder-thickness) 2)])))
 
 (defn screw-insert-shape [bottom-radius top-radius height]
+  "Screw inserts are shaped like a frustum with a dome on top."
   (union (cylinder [bottom-radius top-radius] height)
          (translate [0 0 (/ height 2)] (sphere top-radius))))
 
 (def screw-insert-height 3.8)
 (def screw-insert-bottom-radius (/ 5.31 2))
 (def screw-insert-top-radius (/ 5.1 2))
+(def screw-insert-wall-thickness 1.6)
 
-(defn screw-insert-holes
-  "TODO: doc.
-   but basically it takes a function that places screw holes with the following specs."
+(defn screw-insert-hole
+  "Given a function that places a screw insert's hole, creates the screw insert
+   hole."
   [placement-function c]
   (placement-function c
                       screw-insert-bottom-radius
                       screw-insert-top-radius
                       screw-insert-height))
-(defn screw-insert-outers
-  "TODO: doc.
-   but basically it takes a function that places outer parts of screw holes with the following specs."
+(defn screw-insert-wall
+  "Given a function that places a screw insert's hole, creates the wall around the
+   hole to which the screw insert will attach."
   [placement-function c]
   (placement-function c
-                      (+ screw-insert-bottom-radius 1.6)
-                      (+ screw-insert-top-radius 1.6)
-                      (+ screw-insert-height 1.5)))
-(defn screw-insert-holes-plate
-  "TODO: doc.
-   Takes a function that places screw holes for the bottom plate of the case."
+                      (+ screw-insert-bottom-radius screw-insert-wall-thickness)
+                      (+ screw-insert-top-radius screw-insert-wall-thickness)
+                      (+ screw-insert-height (- screw-insert-wall-thickness 0.1))))
+(defn screw-insert-hole-plate
+  "For the bottom plate of the case: Given a function that places a screw hole,
+   creates a through-hole for an M3 screw."
   [placement-function c]
-  (placement-function c 1.7 1.7 350))
+  (let [m3-through-hole-radius 1.7
+        max-height 350]
+    (placement-function c m3-through-hole-radius m3-through-hole-radius max-height)))
 
-(defn screw-insert [c column row bottom-radius top-radius height]
+(defn screw-insert
+  "Model-independent utility for placing and creating screw inserts."
+  [c column row bottom-radius top-radius height]
   (let [lastcol     (flastcol (get c :configuration-ncols))
         lastrow     (flastrow (get c :configuration-nrows 5))
         shift-right (= column lastcol)

--- a/src/dactyl_keyboard/lightcycle.clj
+++ b/src/dactyl_keyboard/lightcycle.clj
@@ -1089,7 +1089,7 @@
                         (if-not use-external-holder?
                           (union (rj9-space frj9-start c) (usb-holder-hole fusb-holder-position c))
                           (external-holder-space c))
-                        (if use-screw-inserts? (screw-insert-holes screw-placement c) ()))
+                        (if use-screw-inserts? (screw-insert-hole screw-placement c) ()))
             (if (get c :configuration-show-caps?) (caps c) ())
             (if (get c :configuration-show-caps?) (thumbcaps c) ())
             (if-not use-external-holder? (rj9-holder frj9-start c) ()))
@@ -1103,8 +1103,8 @@
     (cut
      (translate [0 0 -0.1]
                 (difference (union (new-case c)
-                                   (if use-screw-inserts? (screw-insert-outers screw-placement c) ()))
-                            (if use-screw-inserts? (translate [0 0 -10] (screw-insert-holes-plate screw-placement c)) ()))))))
+                                   (if use-screw-inserts? (screw-insert-wall screw-placement c) ()))
+                            (if use-screw-inserts? (translate [0 0 -10] (screw-insert-hole-plate screw-placement c)) ()))))))
 
 (defn dactyl-plate-left [c]
   (mirror [-1 0 0] (dactyl-plate-right c)))

--- a/src/dactyl_keyboard/lightcycle.clj
+++ b/src/dactyl_keyboard/lightcycle.clj
@@ -1084,7 +1084,7 @@
             (connectors c)
             (thumb c)
             (difference (union (new-case c)
-                               (if use-screw-inserts? (screw-insert-outers screw-placement c) ())
+                               (if use-screw-inserts? (screw-insert-wall screw-placement c) ())
                                (if-not use-external-holder? (usb-holder fusb-holder-position c) ()))
                         (if-not use-external-holder?
                           (union (rj9-space frj9-start c) (usb-holder-hole fusb-holder-position c))

--- a/src/dactyl_keyboard/lightcycle.clj
+++ b/src/dactyl_keyboard/lightcycle.clj
@@ -1104,7 +1104,7 @@
      (translate [0 0 -0.1]
                 (difference (union (new-case c)
                                    (if use-screw-inserts? (screw-insert-outers screw-placement c) ()))
-                            (if use-screw-inserts? (translate [0 0 -10] (screw-insert-screw-holes screw-placement c)) ()))))))
+                            (if use-screw-inserts? (translate [0 0 -10] (screw-insert-holes-plate screw-placement c)) ()))))))
 
 (defn dactyl-plate-left [c]
   (mirror [-1 0 0] (dactyl-plate-right c)))

--- a/src/dactyl_keyboard/lightcycle.clj
+++ b/src/dactyl_keyboard/lightcycle.clj
@@ -1035,7 +1035,8 @@
       (->> (screw-insert-shape bottom-radius top-radius height)
            (translate [(first position) (second position) (/ height 2)]))))
 
-(defn screw-placement [c bottom-radius top-radius height]
+(defn screw-placement [c shape]
+  "Lightcycle-specific placement of screws."
   (let [lastrow           (if (get c :configuration-use-lastrow?) 3.99 3.55)
         toprow            (if (get c :configuration-use-numrow?) -0.12 0.8)
         ncols             (get c :configuration-ncols)
@@ -1057,11 +1058,11 @@
                             5 3
                             6 3
                             3)]
-    (union (screw-insert c -1.5      4.9       bottom-radius top-radius height)
-           (screw-insert c 2         toprow    bottom-radius top-radius height)
-           (screw-insert c -0.75     2         bottom-radius top-radius height)
-           (screw-insert c middlerow lastrow   bottom-radius top-radius height)
-           (screw-insert c lastcol   lastrow   bottom-radius top-radius height))))
+    (union (screw-placement-common c -1.5      4.9       shape)
+           (screw-placement-common c 2         toprow    shape)
+           (screw-placement-common c -0.75     2         shape)
+           (screw-placement-common c middlerow lastrow   shape)
+           (screw-placement-common c lastcol   lastrow   shape))))
 
 (defn new-case [c]
   (union (front-wall c)
@@ -1084,12 +1085,12 @@
             (connectors c)
             (thumb c)
             (difference (union (new-case c)
-                               (if use-screw-inserts? (screw-insert-wall screw-placement c) ())
+                               (if use-screw-inserts? (screw-placement c (screw-insert-wall c)) ())
                                (if-not use-external-holder? (usb-holder fusb-holder-position c) ()))
                         (if-not use-external-holder?
                           (union (rj9-space frj9-start c) (usb-holder-hole fusb-holder-position c))
                           (external-holder-space c))
-                        (if use-screw-inserts? (screw-insert-hole screw-placement c) ()))
+                        (if use-screw-inserts? (screw-placement c (screw-insert-hole c)) ()))
             (if (get c :configuration-show-caps?) (caps c) ())
             (if (get c :configuration-show-caps?) (thumbcaps c) ())
             (if-not use-external-holder? (rj9-holder frj9-start c) ()))
@@ -1103,8 +1104,8 @@
     (cut
      (translate [0 0 -0.1]
                 (difference (union (new-case c)
-                                   (if use-screw-inserts? (screw-insert-wall screw-placement c) ()))
-                            (if use-screw-inserts? (translate [0 0 -10] (screw-insert-hole-plate screw-placement c)) ()))))))
+                                   (if use-screw-inserts? (screw-placement c (screw-insert-wall c)) ()))
+                            (if use-screw-inserts? (translate [0 0 -10] (screw-placement c (screw-insert-hole-plate c))) ()))))))
 
 (defn dactyl-plate-left [c]
   (mirror [-1 0 0] (dactyl-plate-right c)))

--- a/src/dactyl_keyboard/lightcycle.clj
+++ b/src/dactyl_keyboard/lightcycle.clj
@@ -1100,12 +1100,16 @@
   (mirror [-1 0 0] (dactyl-top-right c)))
 
 (defn dactyl-plate-right [c]
-  (let [use-screw-inserts? (get c :configuration-use-screw-inserts?)]
-    (cut
-     (translate [0 0 -0.1]
-                (difference (union (new-case c)
-                                   (if use-screw-inserts? (screw-placement c (screw-insert-wall c)) ()))
-                            (if use-screw-inserts? (translate [0 0 -10] (screw-placement c (screw-insert-hole-plate c))) ()))))))
+  (let [use-screw-inserts? (get c :configuration-use-screw-inserts?)
+        screw-walls        (if use-screw-inserts?
+                             (screw-placement c (screw-insert-wall c))
+                             ())
+        screw-holes        (if use-screw-inserts?
+                             (screw-placement c (screw-hole c))
+                             ())]
+        (difference (cut (translate [0 0 -0.1] (union (new-case c)
+                                                       screw-walls)
+                     screw-holes)))))
 
 (defn dactyl-plate-left [c]
   (mirror [-1 0 0] (dactyl-plate-right c)))

--- a/src/dactyl_keyboard/manuform.clj
+++ b/src/dactyl_keyboard/manuform.clj
@@ -1599,7 +1599,7 @@
                               (rj9-holder frj9-start c))
                   ())
                 ()))
-       (if use-screw-inserts? (screw-insert-holes screw-placement c) ())
+       (if use-screw-inserts? (screw-insert-hole screw-placement c) ())
        (if-not use-external-holder?
          (case connector-type
            :usb (union  (trrs-usb-holder-space c)
@@ -1624,7 +1624,7 @@
                              (screw-insert-outers screw-placement c)
                              ())
         screw-inners       (if use-screw-inserts?
-                             (translate [0 0 -2] (screw-insert-holes-plate screw-placement c))
+                             (translate [0 0 -2] (screw-insert-hole-plate screw-placement c))
                              ())
         bot                (cut (translate [0 0 -0.1] (union (case-walls c) screw-outers)))
         inner-thing        (difference (translate [0 0 -0.1] (project (union (extrude-linear {:height 5
@@ -1697,8 +1697,8 @@
                      (difference (union case-walls
                                         teensy-holder
                                           ; rj9-holder
-                                        screw-insert-outers)
-                                 (translate [0 0 -10] screw-insert-holes-plate))))))
+                                        screw-insert-wall)
+                                 (translate [0 0 -10] screw-insert-hole-plate))))))
 
 #_(spit "things/left.scad"
         (write-scad (mirror [-1 0 0] model-right)))

--- a/src/dactyl_keyboard/manuform.clj
+++ b/src/dactyl_keyboard/manuform.clj
@@ -1624,7 +1624,7 @@
                              (screw-insert-outers screw-placement c)
                              ())
         screw-inners       (if use-screw-inserts?
-                             (translate [0 0 -2] (screw-insert-screw-holes screw-placement c))
+                             (translate [0 0 -2] (screw-insert-holes-plate screw-placement c))
                              ())
         bot                (cut (translate [0 0 -0.1] (union (case-walls c) screw-outers)))
         inner-thing        (difference (translate [0 0 -0.1] (project (union (extrude-linear {:height 5
@@ -1698,7 +1698,7 @@
                                         teensy-holder
                                           ; rj9-holder
                                         screw-insert-outers)
-                                 (translate [0 0 -10] screw-insert-screw-holes))))))
+                                 (translate [0 0 -10] screw-insert-holes-plate))))))
 
 #_(spit "things/left.scad"
         (write-scad (mirror [-1 0 0] model-right)))

--- a/src/dactyl_keyboard/manuform.clj
+++ b/src/dactyl_keyboard/manuform.clj
@@ -1515,7 +1515,8 @@
 (defn external-holder-space [c]
   (translate (map + (external-holder-position c) [-1.5 (* -1 wall-thickness) 3]) external-holder-cube))
 
-(defn screw-placement [c bottom-radius top-radius height]
+(defn screw-placement [c shape]
+  "Manuform-specific placement of screws."
   (let [use-wide-pinky? (get c :configuration-use-wide-pinky?)
         inner           (get c :configuration-inner-column)
         first-screw-x   (case inner
@@ -1535,11 +1536,11 @@
         var-middle-last (if is-three-mini? -0.3 (if is-five? -0 0.2))
         y-middle-last   (+ lastrow var-middle-last)
         x-middle-last   (if is-five? 1.6 2)]
-    (union (screw-insert c first-screw-x  0               bottom-radius top-radius height)
-           (screw-insert c second-screw-x (- lastrow 0.8) bottom-radius top-radius height)
-           (screw-insert c x-middle-last  y-middle-last   bottom-radius top-radius height)
-           (screw-insert c 3              0               bottom-radius top-radius height)
-           (screw-insert c lastloc        1               bottom-radius top-radius height))))
+    (union (screw-placement-common c first-screw-x  0               shape)
+           (screw-placement-common c second-screw-x (- lastrow 0.8) shape)
+           (screw-placement-common c x-middle-last  y-middle-last   shape)
+           (screw-placement-common c 3              0               shape)
+           (screw-placement-common c lastloc        1               shape))))
 
 (def wire-post-height 7)
 (def wire-post-overhang 3.5)
@@ -1587,7 +1588,7 @@
                 :rj9 (difference (case-walls c)
                                  (rj9-space frj9-start c))
                 (case-walls c))
-              (if use-screw-inserts? (screw-insert-wall screw-placement c) ())
+              (if use-screw-inserts? (screw-placement c (screw-insert-wall c)) ())
               (if-not use-external-holder?
                 (case connector-type
                   :usb (union (pro-micro-holder c)
@@ -1599,7 +1600,7 @@
                               (rj9-holder frj9-start c))
                   ())
                 ()))
-       (if use-screw-inserts? (screw-insert-hole screw-placement c) ())
+       (if use-screw-inserts? (screw-placement c (screw-insert-hole c)) ())
        (if-not use-external-holder?
          (case connector-type
            :usb (union  (trrs-usb-holder-space c)
@@ -1621,10 +1622,10 @@
 (defn plate-right [c]
   (let [use-screw-inserts? (get c :configuration-use-screw-inserts?)
         screw-outers       (if use-screw-inserts?
-                             (screw-insert-wall screw-placement c)
+                             (screw-placement c (screw-insert-wall c))
                              ())
         screw-inners       (if use-screw-inserts?
-                             (translate [0 0 -2] (screw-insert-hole-plate screw-placement c))
+                             (translate [0 0 -2] (screw-placement c (screw-insert-hole-plate c)))
                              ())
         bot                (cut (translate [0 0 -0.1] (union (case-walls c) screw-outers)))
         inner-thing        (difference (translate [0 0 -0.1] (project (union (extrude-linear {:height 5

--- a/src/dactyl_keyboard/manuform.clj
+++ b/src/dactyl_keyboard/manuform.clj
@@ -1621,20 +1621,20 @@
 
 (defn plate-right [c]
   (let [use-screw-inserts? (get c :configuration-use-screw-inserts?)
-        screw-outers       (if use-screw-inserts?
+        screw-walls        (if use-screw-inserts?
                              (screw-placement c (screw-insert-wall c))
                              ())
-        screw-inners       (if use-screw-inserts?
-                             (translate [0 0 -2] (screw-placement c (screw-insert-hole-plate c)))
+        screw-holes        (if use-screw-inserts?
+                             (screw-placement c (screw-hole c))
                              ())
-        bot                (cut (translate [0 0 -0.1] (union (case-walls c) screw-outers)))
-        inner-thing        (difference (translate [0 0 -0.1] (project (union (extrude-linear {:height 5
-                                                                                              :scale  0.1
-                                                                                              :center true} bot)
-                                                                             (cube 50 50 5))))
-                                       screw-inners)]
-    (difference (extrude-linear {:height 3} inner-thing)
-                screw-inners)))
+        plate-perimeter    (union (project screw-walls) (cut (case-walls c)))
+        ; There is no operation for filling convex 2D shapes. Instead, linear
+        ; extrude the 2D shape into a 3D cone, then project that again.
+        plate-filled       (project (extrude-linear {:scale 0.0
+                                                     :height 5
+                                                     :center true} plate-perimeter))]
+    (extrude-linear {:height 3}
+      (difference plate-filled screw-holes))))
 
 (defn plate-left [c]
   (mirror [-1 0 0] (plate-right c)))
@@ -1699,7 +1699,7 @@
                                         teensy-holder
                                           ; rj9-holder
                                         screw-insert-wall)
-                                 (translate [0 0 -10] screw-insert-hole-plate))))))
+                                 (translate [0 0 -10] screw-hole))))))
 
 #_(spit "things/left.scad"
         (write-scad (mirror [-1 0 0] model-right)))

--- a/src/dactyl_keyboard/manuform.clj
+++ b/src/dactyl_keyboard/manuform.clj
@@ -1587,7 +1587,7 @@
                 :rj9 (difference (case-walls c)
                                  (rj9-space frj9-start c))
                 (case-walls c))
-              (if use-screw-inserts? (screw-insert-outers screw-placement c) ())
+              (if use-screw-inserts? (screw-insert-wall screw-placement c) ())
               (if-not use-external-holder?
                 (case connector-type
                   :usb (union (pro-micro-holder c)
@@ -1621,7 +1621,7 @@
 (defn plate-right [c]
   (let [use-screw-inserts? (get c :configuration-use-screw-inserts?)
         screw-outers       (if use-screw-inserts?
-                             (screw-insert-outers screw-placement c)
+                             (screw-insert-wall screw-placement c)
                              ())
         screw-inners       (if use-screw-inserts?
                              (translate [0 0 -2] (screw-insert-hole-plate screw-placement c))


### PR DESCRIPTION
Originally, I only wanted to make a small fix to how screw holes are rendered and propose some screw-related extensions later. Then I realized that the code wasn't ready for the extensions, so I had to refactor it first. Sorry for that. :shrug:

Apart from some renaming here and there, there are two major changes:
* Commit cd1ad5fb57b1550d20fec45b561e86cca564cc6b decouples the creation and placement of screw-related shapes. Beforehand, screw insert dimensions had to be passed around a lot.
* Based on that, commit dea4f21805361b0308f81223695bf6a5a3fda4b7 simplifies the code generating the bottom plate. Using the previous commit, it's possible to represent screw holes for the bottom plate as 2D shapes (not very tall 3D shapes anymore) which makes the code a lot cleaner. It also fixes #112.

WDYT?