### PR TITLE
Fix web thickness not affecting 1.5u button plates

### DIFF
--- a/src/dactyl_keyboard/manuform.clj
+++ b/src/dactyl_keyboard/manuform.clj
@@ -1392,7 +1392,8 @@
 (def trrs-usb-holder-cube
   (cube 17 12 2))
 (defn trrs-usb-holder-space [c]
-  (translate (map + (trrs-usb-holder-position c) [0 (* -1 wall-thickness) 1]) trrs-usb-holder-cube))
+  (let [wall-thickness (get c :configuration-wall-thickness)]
+    (translate (map + (trrs-usb-holder-position c) [0 (* -1 wall-thickness) 1]) trrs-usb-holder-cube)))
 (defn trrs-usb-holder-holder [c]
   (translate (trrs-usb-holder-position c) (cube 19 12 4)))
 
@@ -1514,7 +1515,8 @@
 (def external-holder-cube
   (cube 29.166 30 12.6))
 (defn external-holder-space [c]
-  (translate (map + (external-holder-position c) [-1.5 (* -1 wall-thickness) 3]) external-holder-cube))
+  (let [wall-thickness (get c :configuration-wall-thickness)]
+    (translate (map + (external-holder-position c) [-1.5 (* -1 wall-thickness) 3]) external-holder-cube)))
 
 (defn screw-placement [c bottom-radius top-radius height]
   (let [use-wide-pinky? (get c :configuration-use-wide-pinky?)

--- a/src/dactyl_keyboard/manuform.clj
+++ b/src/dactyl_keyboard/manuform.clj
@@ -459,12 +459,13 @@
       (union (thumb-tr-place c shape)
              (thumb-tl-place c shape)))))
 
-(def larger-plate
-  (let [plate-height (/ (- sa-double-length mount-height) 3)
-        top-plate    (->> (cube mount-width plate-height web-thickness)
-                          (translate [0
-                                      (/ (+ plate-height mount-height -0.20) 2)
-                                      (- plate-thickness (/ web-thickness 2))]))]
+(defn larger-plate [c]
+  (let [web-thickness (get c :configuration-web-thickness)
+        plate-height  (/ (- sa-double-length mount-height) 3)
+        top-plate     (->> (cube mount-width plate-height web-thickness)
+                           (translate [0
+                                       (/ (+ plate-height mount-height -0.20) 2)
+                                       (- plate-thickness (/ web-thickness 2))]))]
     (union top-plate (mirror [0 1 0] top-plate))))
 
 (defn thumbcaps [c]
@@ -476,7 +477,7 @@
   (union
    (thumb-1x-layout c (single-plate c))
    (thumb-15x-layout c (single-plate c))
-   (thumb-15x-layout c larger-plate)))
+   (thumb-15x-layout c (larger-plate c))))
 
 (defn thumb-post-tr [web-thickness]
   (translate [(- (/ mount-width 2) post-adj)


### PR DESCRIPTION
The plates surrounding 1.5u buttons in the thumb cluster always used the default web thickness of 7mm instead of the thickness from the configuration.

Default configuration values (no noticeable problem):
![default](https://user-images.githubusercontent.com/23331603/168157265-e5373735-1f75-4401-a325-ec3f4c379c41.png)

`:configuration-web-thickness 1` before this PR:
![broken](https://user-images.githubusercontent.com/23331603/168157402-a8af03aa-85fc-4b4d-bd24-bb464eae1bd4.png)

`:configuration-web-thickness 1` after this PR:
![fixed](https://user-images.githubusercontent.com/23331603/168157638-338d0bdc-a766-4784-8efc-1cd504b1b90e.png)

